### PR TITLE
fix(TwabRewards): test claimRewards epochs limit

### DIFF
--- a/contracts/TwabRewards.sol
+++ b/contracts/TwabRewards.sol
@@ -32,7 +32,7 @@ contract TwabRewards is ITwabRewards {
 
     /// @notice Keeps track of claimed rewards per user.
     /// @dev _claimedEpochs[promotionId][user] => claimedEpochs
-    /// @dev We pack epochs claimed by a user into a uint256. So we can't store more than 255 epochs.
+    /// @dev We pack epochs claimed by a user into a uint256. So we can't store more than 256 epochs.
     mapping(uint256 => mapping(address => uint256)) internal _claimedEpochs;
 
     /* ============ Events ============ */

--- a/test/TwabRewards.test.ts
+++ b/test/TwabRewards.test.ts
@@ -54,7 +54,7 @@ describe('TwabRewards', () => {
     const tokensPerEpoch = toWei('10000');
     const epochDuration = 604800; // 1 week in seconds
     const numberOfEpochs = 12; // 3 months since 1 epoch runs for 1 week
-    const promotionAmount = tokensPerEpoch.mul(numberOfEpochs);
+    let promotionAmount: BigNumber;
 
     const createPromotion = async (
         ticketAddress: string = ticket.address,
@@ -64,6 +64,8 @@ describe('TwabRewards', () => {
         epochsNumber: number = numberOfEpochs,
         startTimestamp?: number,
     ) => {
+        promotionAmount = epochTokens.mul(epochsNumber);
+
         if (token.mock) {
             await token.mock.transferFrom
                 .withArgs(wallet1.address, twabRewards.address, promotionAmount)
@@ -487,8 +489,7 @@ describe('TwabRewards', () => {
                 epochDuration,
                 numberOfEpochs,
                 startTimestamp,
-            ),
-
+            );
             expect(await twabRewards.callStatic.getCurrentEpochId(1)).to.equal(0);
         });
 
@@ -496,9 +497,7 @@ describe('TwabRewards', () => {
             await createPromotion();
             await increaseTime(epochDuration * 12);
 
-            expect(await twabRewards.callStatic.getCurrentEpochId(1)).to.equal(
-                numberOfEpochs - 1,
-            );
+            expect(await twabRewards.callStatic.getCurrentEpochId(1)).to.equal(numberOfEpochs - 1);
         });
 
         it('should revert if promotion id passed is inexistent', async () => {
@@ -821,6 +820,23 @@ describe('TwabRewards', () => {
             await expect(
                 twabRewards.claimRewards(wallet2.address, promotionId, ['2', '3', '4']),
             ).to.be.revertedWith('TwabRewards/rewards-claimed');
+        });
+
+        it('should fail to claim rewards past 255', async () => {
+            const promotionId = 1;
+
+            const wallet2Amount = toWei('750');
+            const wallet3Amount = toWei('250');
+
+            await ticket.mint(wallet2.address, wallet2Amount);
+            await ticket.mint(wallet3.address, wallet3Amount);
+
+            await createPromotion(ticket.address, rewardToken, tokensPerEpoch, epochDuration, 255);
+
+            await increaseTime(epochDuration * 256);
+
+            await expect(twabRewards.claimRewards(wallet2.address, promotionId, ['256'])).to.be
+                .reverted;
         });
     });
 


### PR DESCRIPTION
Issue: https://github.com/code-423n4/2021-12-pooltogether-findings/issues/3

EpochId has been casted to `uint8` in the following PR: https://github.com/pooltogether/v4-periphery/pull/36/files
This PR test that we can't claim above the 255 epoch ids limit.