### PR TITLE
fix(PrizeDistributionFactoryV2): remove manager role

### DIFF
--- a/contracts/PrizeDistributionFactoryV2.sol
+++ b/contracts/PrizeDistributionFactoryV2.sol
@@ -5,7 +5,7 @@ import "@pooltogether/v4-core/contracts/interfaces/ITicket.sol";
 import "@pooltogether/v4-core/contracts/interfaces/IPrizeDistributionBuffer.sol";
 import "@pooltogether/v4-core/contracts/interfaces/IPrizeDistributionSource.sol";
 import "@pooltogether/v4-core/contracts/libraries/ExtendedSafeCastLib.sol";
-import "@pooltogether/owner-manager-contracts/contracts/Manageable.sol";
+import "@pooltogether/owner-manager-contracts/contracts/Ownable.sol";
 
 import "./interfaces/IPrizeTierHistoryV2.sol";
 
@@ -16,7 +16,7 @@ import "./interfaces/IPrizeTierHistoryV2.sol";
  * to compute the correct prize distribution.  It automatically sets the cardinality based on
  * the DPR (Draw Percentage Rate), prize, minPickCost and the total ticket supply.
  */
-contract PrizeDistributionFactoryV2 is Manageable {
+contract PrizeDistributionFactoryV2 is Ownable {
     using ExtendedSafeCastLib for uint256;
 
     /* ============ Events ============ */
@@ -96,14 +96,13 @@ contract PrizeDistributionFactoryV2 is Manageable {
     /* ============ External Functions ============ */
 
     /**
-     * @notice Allows the owner or manager to push a new prize distribution onto the buffer.
-     * The PrizeTier and Draw for the given draw id will be pulled in, and the prize distribution will be computed.
+     * @notice Push a new prize distribution onto the PrizeDistributionBuffer.
+     *         PrizeTier and Draw for the given draw id will be pulled in and the prize distribution will be computed.
      * @param _drawId The draw id to compute for
      * @return The resulting Prize Distribution
      */
     function pushPrizeDistribution(uint32 _drawId)
         external
-        onlyManagerOrOwner
         returns (IPrizeDistributionBuffer.PrizeDistribution memory)
     {
         IPrizeDistributionBuffer.PrizeDistribution
@@ -117,8 +116,8 @@ contract PrizeDistributionFactoryV2 is Manageable {
     }
 
     /**
-     * @notice Allows the owner or manager to override an existing prize distribution in the buffer.
-     * The PrizeTier and Draw for the given draw id will be pulled in, and the prize distribution will be computed.
+     * @notice Allows the owner to override an existing prize distribution in the buffer.
+     *         PrizeTier and Draw for the given draw id will be pulled in and the prize distribution will be computed.
      * @param _drawId The draw id to compute for
      * @return The resulting Prize Distribution
      */
@@ -229,7 +228,7 @@ contract PrizeDistributionFactoryV2 is Manageable {
          * maxPicks = totalSupply / minPickCost
          * targetPicks = maxPicks / odds = (totalSupply / minPickCost) / ((dpr * totalSupply) / prize)
          * targetPicks = (1 / minPickCost) / ((dpr * 1) / prize) = prize / (dpr * minPickCost)
-        */
+         */
         uint256 _targetPicks = (_prize * RATE_NORMALIZATION) / (_dpr * _minPickCost);
 
         do {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "peerDependencies": {
         "@openzeppelin/contracts": "4.7.3",
-        "@pooltogether/v4-core": "1.3.0-beta.1"
+        "@pooltogether/v4-core": "1.3.0"
     },
     "devDependencies": {
         "@nomiclabs/hardhat-ethers": "2.2.0",
@@ -36,7 +36,7 @@
         "@nomiclabs/hardhat-waffle": "2.0.3",
         "@openzeppelin/contracts": "4.7.3",
         "@pooltogether/aave-yield-source": "1.2.1",
-        "@pooltogether/v4-core": "1.3.0-beta.1",
+        "@pooltogether/v4-core": "1.3.0",
         "@studydefi/money-legos": "2.4.2",
         "@typechain/ethers-v5": "10.1.0",
         "@typechain/hardhat": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pooltogether/v4-periphery",
-    "version": "1.3.0-beta.1",
+    "version": "1.3.0",
     "description": "PoolTogether V4 Periphery",
     "main": "index.js",
     "license": "GPL-3.0",

--- a/test/PrizeDistributionFactoryV2.test.ts
+++ b/test/PrizeDistributionFactoryV2.test.ts
@@ -447,24 +447,6 @@ describe('PrizeDistributionFactoryV2', () => {
                 .to.emit(prizeDistributionFactory, 'PrizeDistributionPushed')
                 .withArgs(1);
         });
-
-        it('should push the prize distribution if manager', async () => {
-            await prizeDistributionFactory.transferOwnership(wallet2.address);
-            await prizeDistributionFactory.connect(wallet2).claimOwnership();
-
-            await setupMocks();
-            await prizeDistributionBuffer.mock.pushPrizeDistribution.returns(true);
-
-            await expect(prizeDistributionFactory.connect(wallet2).pushPrizeDistribution(1))
-                .to.emit(prizeDistributionFactory, 'PrizeDistributionPushed')
-                .withArgs(1);
-        });
-
-        it('should fail to push if not manager or owner', async () => {
-            await expect(
-                prizeDistributionFactory.connect(wallet2).pushPrizeDistribution(1),
-            ).to.be.revertedWith('Manageable/caller-not-manager-or-owner');
-        });
     });
 
     describe('setPrizeDistribution()', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,27 +1251,37 @@
   resolved "https://registry.yarnpkg.com/@pooltogether/owner-manager-contracts/-/owner-manager-contracts-1.1.0.tgz#776f1b96a81cec05bfe6575583b4b239a4038fa9"
   integrity sha512-1PqkzSE/AJ4luGhpEfaN9YnHI7mbe63zy92iXgNwHJ4XDqerm+hfJsggrXK7BUyUkAIFLFf8+Ol0TntZAUTedw==
 
-"@pooltogether/pooltogether-rng-contracts@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pooltogether/pooltogether-rng-contracts/-/pooltogether-rng-contracts-1.4.0.tgz#310b9667a1123cfcce718aa6d8eba7c434a53c75"
-  integrity sha512-dNgDpDsCMxUxaz8u6OfpjSBtMOdcp8QkLC3cwJ6E++4ux0qY2ON+ZqJEHIC3q4ZVJ4Xf6FikMJF0a8SVNtl8Zw==
+"@pooltogether/pooltogether-rng-contracts@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@pooltogether/pooltogether-rng-contracts/-/pooltogether-rng-contracts-1.5.1.tgz#cc2fd10d1b7a61be00d5b7136f94ff3c74cc6d33"
+  integrity sha512-GEfsPcdKD8Hpa5F4Z16rgkKIWP93cQYEwN5aoYCOpNUaiHB5kdI1s+tNECGD6ILDWfNpQq0MP6gfYoRV9DV0Ng==
+  dependencies:
+    "@pooltogether/owner-manager-contracts" "1.1.0"
 
-"@pooltogether/v4-core@1.3.0-beta.1":
-  version "1.3.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@pooltogether/v4-core/-/v4-core-1.3.0-beta.1.tgz#5fbb6123753b006b255f56c5a54174963c4d4146"
-  integrity sha512-w4jqm5Oq9Pj3hOuiXexTvI5Et04O4CJuSRXNBXz+YJ1oSylSbOzoVU1DuU0DNaHtMINFjTsyZ8AOh1+NAiTURg==
+"@pooltogether/v4-core@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@pooltogether/v4-core/-/v4-core-1.3.0.tgz#6d74a610a2ee0c59e7138ec66d97beade684d700"
+  integrity sha512-fjtu411I+YHEfF1XfUb7Zo2XSUCzkBbrtsS/HZsX8fKYVGpO3n10QE7YN9oA+2sg5dPK19XpSuYfole97ChW9w==
   dependencies:
     "@openzeppelin/contracts" "4.3.1"
     "@pooltogether/fixed-point" "1.0.0"
     "@pooltogether/owner-manager-contracts" "1.1.0"
-    "@pooltogether/pooltogether-rng-contracts" "1.4.0"
-    "@pooltogether/yield-source-interface" "1.3.0"
+    "@pooltogether/pooltogether-rng-contracts" "1.5.1"
+    "@pooltogether/yield-source-interface" "1.4.0"
     deploy-eip-1820 "1.0.0"
 
 "@pooltogether/yield-source-interface@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@pooltogether/yield-source-interface/-/yield-source-interface-1.3.0.tgz#93e9c12bb2d62e2215bb2f9c9d391a092e6eb6d5"
   integrity sha512-HEo4iB/emXz/QZ0J1ilWVtBk0NFAmIQe80xG3hbSfLI/SnAMIHixGq/TSw3IWu4RGEf2ttoMc44Bxd+IdbZisA==
+
+"@pooltogether/yield-source-interface@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@pooltogether/yield-source-interface/-/yield-source-interface-1.4.0.tgz#50cddcc7bb4609e673329b826d5c47a6a774f766"
+  integrity sha512-Xy7LeS3Bk5/fx0HxH6YgTveo3YZGN7wBo2OkMG2MV0HtaC8l7aXMEyw6PGXFjERvqtYsyaTa6nQczzNRUt0PfQ==
+  dependencies:
+    hardhat-deploy "^0.11.4"
+    hardhat-deploy-ethers "^0.3.0-beta.13"
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
@@ -5605,7 +5615,7 @@ hardhat-dependency-compiler@1.1.3:
   resolved "https://registry.yarnpkg.com/hardhat-dependency-compiler/-/hardhat-dependency-compiler-1.1.3.tgz#1e49e23f68878bd713f860c66648a711bc4a4a79"
   integrity sha512-bCDqsOxGST6WkbMvj4lPchYWidNSSBm5CFnkyAex1T11cGmr9otZTGl81W6f9pmrtBXbKCvr3OSuNJ6Q394sAw==
 
-hardhat-deploy-ethers@0.3.0-beta.13:
+hardhat-deploy-ethers@0.3.0-beta.13, hardhat-deploy-ethers@^0.3.0-beta.13:
   version "0.3.0-beta.13"
   resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz#b96086ff768ddf69928984d5eb0a8d78cfca9366"
   integrity sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==
@@ -5614,6 +5624,25 @@ hardhat-deploy@0.11.18:
   version "0.11.18"
   resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.18.tgz#076b4f5e7dc78bc144c2807112fb4bc764a7a7d1"
   integrity sha512-Zs5Gr23/HEcYPjQgcSJLlXkR2/WOp24O9Af+7qA540sCDvHjuQ7WhHG/fB2cjPel0Ajf0TzXx1uVViWtbKLqTg==
+  dependencies:
+    "@types/qs" "^6.9.7"
+    axios "^0.21.1"
+    chalk "^4.1.2"
+    chokidar "^3.5.2"
+    debug "^4.3.2"
+    enquirer "^2.3.6"
+    ethers "^5.5.3"
+    form-data "^4.0.0"
+    fs-extra "^10.0.0"
+    match-all "^1.2.6"
+    murmur-128 "^0.2.1"
+    qs "^6.9.4"
+    zksync-web3 "^0.8.1"
+
+hardhat-deploy@^0.11.4:
+  version "0.11.22"
+  resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.22.tgz#9799c0266a0fc40c84690de54760f1b4dae5e487"
+  integrity sha512-ZhHVNB7Jo2l8Is+KIAk9F8Q3d7pptyiX+nsNbIFXztCz81kaP+6kxNODRBqRCy7SOD3It4+iKCL6tWsPAA/jVQ==
   dependencies:
     "@types/qs" "^6.9.7"
     axios "^0.21.1"


### PR DESCRIPTION
This PR removes the `onlyManagerOrOwner` modifier from the `pushPrizeDistribution` function, making this function callable by anyone.
Since we are removing the various timelocks with the DPR upgrade, anyone can push the prize distribution and this function is not only callable by the BeaconTimelockTrigger anymore.

This change is safe because the prize distribution is calculated by:
- retrieving the PrizeTier from the PrizeTierHistory
=> if no PrizeTier has been pushed onto the PrizeTierHistory, the binary search will revert with the error: `BinarySearchLib/draw-id-out-of-range`
=> otherwise it will use the latest pushed PrizeTier
=> PrizeTier can only be pushed by the manager or owner of the PrizeTierHistoryV2 contract
- retrieving the Draw from the DrawBuffer
=> if the Draw requested does not exist, it will revert with the error: `DRB/future-draw`
=> if the Draw requested already exist, it will revert with the error: `DRB/must-be-contig` when trying to push onto the buffer
=> anyone can start a Draw by calling `startDraw` on the DrawBeacon contract, 
so to avoid being front-run, the deployer of the pool need to deploy the DrawBeacon contract with a `beaconPeriodStart` value set to the time at which they want to start the first draw

In summary, it is not possible to push a new PrizeDistribution for a Draw that does not or already exist.
